### PR TITLE
Fix carousel item focus after click

### DIFF
--- a/script.js
+++ b/script.js
@@ -565,6 +565,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                     setActiveCarousel('shield');
                     generateBadge();
                     updateCarouselStates();
+                    // Keep focus on the carousel box so keyboard navigation works
+                    shieldBox.focus();
                 };
             });
 
@@ -575,6 +577,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                     setActiveCarousel('ribbon');
                     generateBadge();
                     updateCarouselStates();
+                    // Maintain focus for subsequent arrow key navigation
+                    ribbonBox.focus();
                 };
             });
 
@@ -585,6 +589,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                     setActiveCarousel('icon');
                     generateBadge();
                     updateCarouselStates();
+                    // Keep focus on the icon carousel for keyboard arrows
+                    iconBox.focus();
                 };
             });
 


### PR DESCRIPTION
## Summary
- keep focus on carousel box when clicking items to prevent stray outlines

## Testing
- `npm test` *(fails: could not find package.json)*