### PR TITLE
Add click state tracking for carousel items

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,8 @@
     const colors = ['#2196f3'];
     let baseColor = colors[0];
     let activeCarousel = null; // Track the active carousel
+    let currentSelection = null; // Last clicked carousel item element
+    let currentCarouselContainer = null; // Parent container of the last clicked item
 // Load a small set of icons immediately so the page remains responsive
 let iconPaths = {
   "emoji_events": "M19,5h -2V3H7v2H5C3.9,5,3,5.9,3,7v1c0,2.55,1.92,4.63,4.39,4.94c0.63,1.5,1.98,2.63,3.61,2.96V19H7v2h10v -2h -4v -3.1c1.63 -0.33,2.98 -1.46,3.61 -2.96C19.08,12.63,21,10.55,21,8V7C21,5.9,20.1,5,19,5z M5,8V7h2v3.82C5.84,10.4,5,9.3,5,8z M12,14c -1.65,0 -3-1.35 -3-3V5h6v6C15,12.65,13.65,14,12,14z M19,8c0,1.3 -0.84,2.4 -2,2.82V7h2V8z",
@@ -562,11 +564,10 @@ document.addEventListener('DOMContentLoaded', async function() {
                 el.onclick = () => {
                     const idx = +el.getAttribute('data-idx');
                     window.currentShield = shieldOptions[idx];
-                    setActiveCarousel('shield');
+                    currentSelection = el;
+                    currentCarouselContainer = shieldDiv;
                     generateBadge();
                     updateCarouselStates();
-                    // Keep focus on the carousel box so keyboard navigation works
-                    shieldBox.focus();
                 };
             });
 
@@ -574,11 +575,10 @@ document.addEventListener('DOMContentLoaded', async function() {
                 el.onclick = () => {
                     const idx = +el.getAttribute('data-idx');
                     window.currentRibbon = ribbonOptions[idx];
-                    setActiveCarousel('ribbon');
+                    currentSelection = el;
+                    currentCarouselContainer = ribbonDiv;
                     generateBadge();
                     updateCarouselStates();
-                    // Maintain focus for subsequent arrow key navigation
-                    ribbonBox.focus();
                 };
             });
 
@@ -586,11 +586,10 @@ document.addEventListener('DOMContentLoaded', async function() {
                 el.onclick = () => {
                     const idx = +el.getAttribute('data-idx');
                     window.currentIcon = iconOptions[idx];
-                    setActiveCarousel('icon');
+                    currentSelection = el;
+                    currentCarouselContainer = iconDiv;
                     generateBadge();
                     updateCarouselStates();
-                    // Keep focus on the icon carousel for keyboard arrows
-                    iconBox.focus();
                 };
             });
 


### PR DESCRIPTION
## Summary
- add `currentSelection` and `currentCarouselContainer` to track which item was clicked
- update item click handlers so they record selection and avoid focusing containers

## Testing
- `npm test` *(fails: package.json missing)*