### PR TITLE
Move inline styles to CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
-<body style="background-color:#222;">
-    <div style="position:relative;z-index:0;max-width:940px;margin:8px auto 0 auto;">
-        <div style="position:absolute;z-index:0;top:0;left:0;width:100%;height:100%;background:#f4f8fc;border-radius:24px;box-shadow:0 2px 16px rgba(0,0,0,0.08);"></div>
-        <div class="container" style="position:relative;z-index:1;padding:4px 24px 32px 24px;">
-            <div style="width:100%;display:flex;flex-direction:column;align-items:center;">
-                <svg id="badgeSvg" width="300" height="300" style="display:block;margin:auto;margin-bottom:12px;" role="img" aria-label="Badge Preview">
+<body>
+    <div class="main-wrapper">
+        <div class="background-box"></div>
+        <div class="container">
+            <div class="preview-wrapper">
+                <svg id="badgeSvg" width="300" height="300" role="img" aria-label="Badge Preview">
                     <g transform="scale(1.35) translate(55, 55)">
                         <!-- Shield -->
                         <path id="shieldPath" d="M100,20 L180,60 L180,140 C180,180 140,200 100,200 C60,200 20,180 20,140 L20,60 Z" fill="currentColor"/>
@@ -26,17 +26,17 @@
                 </svg>
                 <div class="badge-controls">
                     <div id="colorPicker" class="color-picker" aria-label="Preset colors"></div>
-                    <input type="color" id="customColor" value="#2196f3" style="width:40px;height:40px;border:none;background:none;cursor:pointer;border-radius:8px;overflow:hidden;"
+                    <input type="color" id="customColor" value="#2196f3"
                            aria-label="Select badge color" role="button" title="Select badge color">
                     <button type="button" onclick="downloadPNG()" class="save-badge-btn" aria-label="Save your badge">
                         <span class="material-icons">download</span>
                         Save Badge
                     </button>
                 </div>
-                <div id="iconCarouselBox" class="carousel-box" style="display:inline-block;margin:4px;padding:4px;border:1px solid #ccc;border-radius:4px;background:#fff;vertical-align:top;width:300px;" tabindex="0" role="group" aria-label="Icon options">
+                <div id="iconCarouselBox" class="carousel-box" tabindex="0" role="group" aria-label="Icon options">
                     <div class="carousel-label">Select Icon</div>
-                    <div id="iconCarousel" style="display:inline-block;position:relative;" tabindex="-1" role="presentation">
-                        <div id="iconCarouselItems" class="carousel-items" style="display:inline-block;overflow-x:auto;white-space:nowrap;width:280px;vertical-align:middle;padding:4px;" role="listbox" aria-label="Icon options" tabindex="-1"></div>
+                    <div id="iconCarousel" tabindex="-1" role="presentation">
+                        <div id="iconCarouselItems" class="carousel-items" role="listbox" aria-label="Icon options" tabindex="-1"></div>
                     </div>
                 </div>
                 <div id="carouselContainer">
@@ -50,7 +50,7 @@
                     </div>
                 </div>
             </div>
-            <form class="controls" style="display:flex;flex-direction:column;gap:12px;width:100%;max-width:350px;margin:auto;">
+            <form class="controls">
                 <!-- Icon dropdown removed -->
             </form>
         </div>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,14 @@
-        body { font-family: Arial, sans-serif; padding: 20px; background-color: #f4f8fc; color: #333; }
-        .container { display: flex; flex-direction: column; gap: 0; max-width: 900px; margin: auto; align-items: stretch; position: relative; }
-        .controls { flex: 1; }
+        body { font-family: Arial, sans-serif; padding: 20px; background-color: #222; color: #333; }
+        .container { display: flex; flex-direction: column; gap: 0; max-width: 900px; margin: auto; align-items: stretch; position: relative; padding: 4px 24px 32px 24px; z-index: 1; }
+        .controls {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            width: 100%;
+            max-width: 350px;
+            margin: auto;
+        }
         select, input[type="text"] { width: 100%; padding: 8px; margin-top: 6px; margin-bottom: 0; box-sizing: border-box; }
         button { padding: 0; cursor: pointer; }
         svg { border: 0; margin-bottom: 12px; }
@@ -18,6 +26,60 @@
         .color-picker { display: flex; flex-wrap: wrap; gap: 3px; margin-bottom: 15px; max-width: 240px; }
         .color-chip { width: 20px; height: 20px; cursor: pointer; border-radius: 4px; border: 2px solid transparent; }
         .selected { border: 0px solid black; }
+        .main-wrapper {
+            position: relative;
+            z-index: 0;
+            max-width: 940px;
+            margin: 8px auto 0 auto;
+        }
+        .background-box {
+            position: absolute;
+            z-index: 0;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: #f4f8fc;
+            border-radius: 24px;
+            box-shadow: 0 2px 16px rgba(0,0,0,0.08);
+        }
+        .preview-wrapper {
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        #badgeSvg {
+            display: block;
+            margin: auto;
+            margin-bottom: 12px;
+        }
+        #customColor {
+            width: 40px;
+            height: 40px;
+            border: none;
+            background: none;
+            cursor: pointer;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+        #iconCarouselBox {
+            display: inline-block;
+            margin: 4px;
+            padding: 4px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: #fff;
+            vertical-align: top;
+            width: 300px;
+        }
+        #iconCarousel {
+            display: inline-block;
+            position: relative;
+        }
+        #iconCarouselItems {
+            padding: 4px;
+        }
         .material-icons { font-size: 64px; }
         #carouselContainer {
             display: flex;


### PR DESCRIPTION
## Summary
- transfer inline HTML styles to stylesheet
- add classes for outer layout wrappers
- style color input and carousel elements via CSS

## Testing
- `node -e "require('./main.js');"` *(fails: window is not defined)*