### PR TITLE
Improve accessibility announcements

### DIFF
--- a/carousel.js
+++ b/carousel.js
@@ -1,5 +1,6 @@
 import { iconPaths } from './icons.js';
 import { generateBadge } from './badgeGenerator.js';
+import { announce } from './utils.js';
 
 export const ribbonOptions = [
   'rect', 'rounded', 'concave', 'pointed', 'chevron',
@@ -195,6 +196,7 @@ export function updateCarousels() {
         window.currentShield = shieldOptions[idx];
         generateBadge();
         updateCarouselStates();
+        announce(`Shield changed to ${window.currentShield.replace(/-/g, ' ')}`);
       };
     });
     ribbonDiv.querySelectorAll('.carousel-item').forEach(el => {
@@ -203,6 +205,7 @@ export function updateCarousels() {
         window.currentRibbon = ribbonOptions[idx];
         generateBadge();
         updateCarouselStates();
+        announce(`Ribbon changed to ${window.currentRibbon.replace(/-/g, ' ')}`);
       };
     });
     iconDiv.querySelectorAll('.carousel-item').forEach(el => {
@@ -211,6 +214,7 @@ export function updateCarousels() {
         window.currentIcon = iconOptions[idx];
         generateBadge();
         updateCarouselStates();
+        announce(`Icon changed to ${window.currentIcon.replace(/_/g, ' ')}`);
       };
     });
     setTimeout(() => {
@@ -236,6 +240,7 @@ export function moveCarousel(type, dir) {
       window.currentShield = shieldOptions[newIdx];
       generateBadge();
       updateCarouselStates();
+      announce(`Shield changed to ${window.currentShield.replace(/-/g, ' ')}`);
       requestAnimationFrame(() => {
         const container = document.querySelector('#shieldCarousel .carousel-items');
         scrollToItem(container, `shield-carousel-item-${newIdx}`);
@@ -248,6 +253,7 @@ export function moveCarousel(type, dir) {
       window.currentRibbon = ribbonOptions[newIdx];
       generateBadge();
       updateCarouselStates();
+      announce(`Ribbon changed to ${window.currentRibbon.replace(/-/g, ' ')}`);
       requestAnimationFrame(() => {
         const container = document.querySelector('#ribbonCarousel .carousel-items');
         scrollToItem(container, `ribbon-carousel-item-${newIdx}`);

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import { iconPaths, loadIconChunk } from './icons.js';
 import { setBaseColor, generateBadge, showTextInput, downloadPNG } from './badgeGenerator.js';
 import { updateCarousels, updateCarouselStates, moveCarousel, scrollToItem } from "./carousel.js";
+import { announce } from './utils.js';
 
 window.downloadPNG = downloadPNG;
 
@@ -17,14 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setBaseColor(this.value);
     generateBadge();
     const colorName = this.value;
-    const announcement = document.createElement('div');
-    announcement.setAttribute('aria-live', 'polite');
-    announcement.setAttribute('aria-atomic', 'true');
-    announcement.style.position = 'absolute';
-    announcement.style.left = '-9999px';
-    announcement.textContent = `Color changed to ${colorName}`;
-    document.body.appendChild(announcement);
-    setTimeout(() => announcement.remove(), 1000);
+    announce(`Color changed to ${colorName}`);
   });
 
   updateCarousels();
@@ -95,6 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.currentIcon = iconOptions[idx];
       generateBadge();
       updateCarouselStates();
+      announce(`Icon changed to ${window.currentIcon.replace(/_/g, ' ')}`);
       requestAnimationFrame(() => {
         const container = document.querySelector('#iconCarousel .carousel-items');
         scrollToItem(container, `icon-carousel-item-${idx}`);

--- a/utils.js
+++ b/utils.js
@@ -9,3 +9,14 @@ export function adjustColor(col, amt) {
 export function showError(msg) {
   console.error(msg);
 }
+
+export function announce(message) {
+  const announcement = document.createElement('div');
+  announcement.setAttribute('aria-live', 'polite');
+  announcement.setAttribute('aria-atomic', 'true');
+  announcement.style.position = 'absolute';
+  announcement.style.left = '-9999px';
+  announcement.textContent = message;
+  document.body.appendChild(announcement);
+  setTimeout(() => announcement.remove(), 1000);
+}


### PR DESCRIPTION
## Summary
- announce shield/ribbon/icon selection changes
- centralize announcement helper
- use live region for color changes

## Testing
- `node --check main.js`
- `node --check carousel.js`
- `node --check utils.js`
- `npm test` *(fails: could not find package.json)*